### PR TITLE
Add wired UART split firmware variants (corne, lily58, sofle)

### DIFF
--- a/corne/boards/shields/wired/Kconfig.defconfig
+++ b/corne/boards/shields/wired/Kconfig.defconfig
@@ -1,0 +1,8 @@
+if SHIELD_WIRED
+
+# Inter-half comms go over the wire, not BLE. Host connectivity (USB/BLE)
+# is unaffected. Only one split transport can be active per build.
+config ZMK_SPLIT_BLE
+    default n
+
+endif

--- a/corne/boards/shields/wired/Kconfig.shield
+++ b/corne/boards/shields/wired/Kconfig.shield
@@ -1,0 +1,2 @@
+config SHIELD_WIRED
+    def_bool $(shields_list_contains,wired)

--- a/corne/boards/shields/wired/wired.overlay
+++ b/corne/boards/shields/wired/wired.overlay
@@ -1,0 +1,21 @@
+/*
+ * Add-on shield: full-duplex wired UART split transport.
+ *
+ * Stacked on top of the corne_left / corne_right shields, e.g.
+ *   shield: corne_left wired
+ *
+ * Uses the Pro-Micro interconnect's predefined UART (&pro_micro_serial),
+ * available on both nice_nano_v2 and mikoto. Full-duplex requires both
+ * data conductors (TX/RX) routed through the TRRS connector.
+ */
+
+&pro_micro_serial {
+    status = "okay";
+};
+
+/ {
+    wired_split {
+        compatible = "zmk,wired-split";
+        device = <&pro_micro_serial>;
+    };
+};

--- a/corne/corne.yaml
+++ b/corne/corne.yaml
@@ -20,6 +20,28 @@ include:
     snippet: studio-rpc-usb-uart
   - board: mikoto@7.2
     shield: corne_right nice_view_adapter nice_view
+  # Wired UART split variants (inter-half comms over TRRS data wires, not BLE).
+  # Separate firmware from the wireless builds above — flash one set or the other.
+  - board: nice_nano_v2
+    shield: corne_left wired
+    snippet: studio-rpc-usb-uart
+  - board: nice_nano_v2
+    shield: corne_right wired
+  - board: nice_nano_v2
+    shield: corne_left nice_view_adapter nice_view wired
+    snippet: studio-rpc-usb-uart
+  - board: nice_nano_v2
+    shield: corne_right nice_view_adapter nice_view wired
+  - board: mikoto@7.2
+    shield: corne_left wired
+    snippet: studio-rpc-usb-uart
+  - board: mikoto@7.2
+    shield: corne_right wired
+  - board: mikoto@7.2
+    shield: corne_left nice_view_adapter nice_view wired
+    snippet: studio-rpc-usb-uart
+  - board: mikoto@7.2
+    shield: corne_right nice_view_adapter nice_view wired
   - board: nice_nano_v2
     shield: settings_reset
   - board: mikoto@7.2

--- a/lily58/boards/shields/wired/Kconfig.defconfig
+++ b/lily58/boards/shields/wired/Kconfig.defconfig
@@ -1,0 +1,8 @@
+if SHIELD_WIRED
+
+# Inter-half comms go over the wire, not BLE. Host connectivity (USB/BLE)
+# is unaffected. Only one split transport can be active per build.
+config ZMK_SPLIT_BLE
+    default n
+
+endif

--- a/lily58/boards/shields/wired/Kconfig.shield
+++ b/lily58/boards/shields/wired/Kconfig.shield
@@ -1,0 +1,2 @@
+config SHIELD_WIRED
+    def_bool $(shields_list_contains,wired)

--- a/lily58/boards/shields/wired/wired.overlay
+++ b/lily58/boards/shields/wired/wired.overlay
@@ -1,0 +1,21 @@
+/*
+ * Add-on shield: full-duplex wired UART split transport.
+ *
+ * Stacked on top of the lily58_left / lily58_right shields, e.g.
+ *   shield: lily58_left wired
+ *
+ * Uses the Pro-Micro interconnect's predefined UART (&pro_micro_serial),
+ * available on both nice_nano_v2 and mikoto. Full-duplex requires both
+ * data conductors (TX/RX) routed through the TRRS connector.
+ */
+
+&pro_micro_serial {
+    status = "okay";
+};
+
+/ {
+    wired_split {
+        compatible = "zmk,wired-split";
+        device = <&pro_micro_serial>;
+    };
+};

--- a/lily58/lily58.yaml
+++ b/lily58/lily58.yaml
@@ -20,6 +20,28 @@ include:
     snippet: studio-rpc-usb-uart
   - board: mikoto@7.2
     shield: lily58_right nice_view_adapter nice_view
+  # Wired UART split variants (inter-half comms over TRRS data wires, not BLE).
+  # Separate firmware from the wireless builds above — flash one set or the other.
+  - board: nice_nano_v2
+    shield: lily58_left wired
+    snippet: studio-rpc-usb-uart
+  - board: nice_nano_v2
+    shield: lily58_right wired
+  - board: nice_nano_v2
+    shield: lily58_left nice_view_adapter nice_view wired
+    snippet: studio-rpc-usb-uart
+  - board: nice_nano_v2
+    shield: lily58_right nice_view_adapter nice_view wired
+  - board: mikoto@7.2
+    shield: lily58_left wired
+    snippet: studio-rpc-usb-uart
+  - board: mikoto@7.2
+    shield: lily58_right wired
+  - board: mikoto@7.2
+    shield: lily58_left nice_view_adapter nice_view wired
+    snippet: studio-rpc-usb-uart
+  - board: mikoto@7.2
+    shield: lily58_right nice_view_adapter nice_view wired
   - board: nice_nano_v2
     shield: settings_reset
   - board: mikoto@7.2

--- a/sofle/boards/shields/wired/Kconfig.defconfig
+++ b/sofle/boards/shields/wired/Kconfig.defconfig
@@ -1,0 +1,8 @@
+if SHIELD_WIRED
+
+# Inter-half comms go over the wire, not BLE. Host connectivity (USB/BLE)
+# is unaffected. Only one split transport can be active per build.
+config ZMK_SPLIT_BLE
+    default n
+
+endif

--- a/sofle/boards/shields/wired/Kconfig.shield
+++ b/sofle/boards/shields/wired/Kconfig.shield
@@ -1,0 +1,2 @@
+config SHIELD_WIRED
+    def_bool $(shields_list_contains,wired)

--- a/sofle/boards/shields/wired/wired.overlay
+++ b/sofle/boards/shields/wired/wired.overlay
@@ -1,0 +1,21 @@
+/*
+ * Add-on shield: full-duplex wired UART split transport.
+ *
+ * Stacked on top of the sofle_left / sofle_right shields, e.g.
+ *   shield: sofle_left wired
+ *
+ * Uses the Pro-Micro interconnect's predefined UART (&pro_micro_serial),
+ * available on both nice_nano_v2 and mikoto. Full-duplex requires both
+ * data conductors (TX/RX) routed through the TRRS connector.
+ */
+
+&pro_micro_serial {
+    status = "okay";
+};
+
+/ {
+    wired_split {
+        compatible = "zmk,wired-split";
+        device = <&pro_micro_serial>;
+    };
+};

--- a/sofle/sofle.yaml
+++ b/sofle/sofle.yaml
@@ -20,6 +20,28 @@ include:
     snippet: studio-rpc-usb-uart
   - board: mikoto@7.2
     shield: sofle_right nice_view_adapter nice_view
+  # Wired UART split variants (inter-half comms over TRRS data wires, not BLE).
+  # Separate firmware from the wireless builds above — flash one set or the other.
+  - board: nice_nano_v2
+    shield: sofle_left wired
+    snippet: studio-rpc-usb-uart
+  - board: nice_nano_v2
+    shield: sofle_right wired
+  - board: nice_nano_v2
+    shield: sofle_left nice_view_adapter nice_view wired
+    snippet: studio-rpc-usb-uart
+  - board: nice_nano_v2
+    shield: sofle_right nice_view_adapter nice_view wired
+  - board: mikoto@7.2
+    shield: sofle_left wired
+    snippet: studio-rpc-usb-uart
+  - board: mikoto@7.2
+    shield: sofle_right wired
+  - board: mikoto@7.2
+    shield: sofle_left nice_view_adapter nice_view wired
+    snippet: studio-rpc-usb-uart
+  - board: mikoto@7.2
+    shield: sofle_right nice_view_adapter nice_view wired
   - board: nice_nano_v2
     shield: settings_reset
   - board: mikoto@7.2


### PR DESCRIPTION
## What

Adds **full-duplex wired UART** split firmware alongside the existing wireless (BLE) builds for `corne`, `lily58`, and `sofle`.

Wired vs. wireless is a **build-time** transport choice in ZMK — only one transport can be active per build — so wired needs its own firmware outputs. Customers flash either the wireless set *or* the wired set.

## How

For each split, a small add-on `wired` shield (modeled on the existing `nice_view_adapter` adapter shield):

- `wired.overlay` — enables `&pro_micro_serial` and declares a `compatible = "zmk,wired-split"` node
- `Kconfig.defconfig` — sets `CONFIG_ZMK_SPLIT_BLE=n` so inter-half comms run over the TRRS data wires
- `Kconfig.shield` — the `SHIELD_WIRED` gate

The 8 existing split build-matrix entries are mirrored with ` wired` appended to each shield (e.g. `corne_left wired`). The combined shield name auto-produces a distinct artifact filename (`corne_left wired-nice_nano_v2-zmk.uf2`), so there is no collision with the wireless `.uf2`s and no CI changes are needed.

## ⚠️ Verify before treating wired as supported

- **TRRS data wiring** — full-duplex UART needs *both* data conductors (TX/RX) routed through the TRRS connector. Confirm per PCB.
- **`&pro_micro_serial` on mikoto** — confirm it exists and is pin-mapped to the inter-half connector (may differ from nice_nano).
- Wired UART is a newer ZMK feature aimed at early adopters; supports one central ↔ one peripheral.

## Companion change

Customer download links are added in `keebd-docs` (`docs/firmware/index.mdx`). Those links 404 until this PR merges and the workflows build + commit the new `.uf2`s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wired split keyboard support for Corne, Lily58, and Sofle keyboards, enabling inter-half communication via UART over TRRS connectors as an alternative to wireless connectivity.
  * Users can now select wired or wireless firmware variants during builds for compatible keyboard configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->