### PR TITLE
Fix Zephyr 4.1 builds: board variants, pin ZMK, publish via Releases

### DIFF
--- a/.github/workflows/corne.yml
+++ b/.github/workflows/corne.yml
@@ -28,18 +28,22 @@ jobs:
       parse_args: ""  # map of extra args to pass to `keymap parse`, e.g. "corne:'-l Def Lwr Rse' cradio:''"
       draw_args: ""   # map of extra args to pass to `keymap draw`, e.g. "corne:'-k corne_rotated' cradio:'-k paroxysm'"
 
-  corne-store:
-    if: always()
+  corne-release:
     needs: corne-build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-    - uses: actions/checkout@v4
     - uses: actions/download-artifact@v4
       with:
-        path: corne
+        path: firmware
         merge-multiple: true
-    - uses: sylvanld/action-storage@v1
+    - name: Publish firmware as a rolling release
+      uses: softprops/action-gh-release@v2
       with:
-        src: corne
-        dst: ./
-        storage-branch: main
+        tag_name: corne-firmware
+        name: Corne Firmware (latest)
+        body: |
+          Latest Corne ZMK firmware, built automatically from `main`.
+          Includes Wireless (BLE) and Wired (UART) variants for nice!nano and Mikoto.
+        files: firmware/*.uf2

--- a/.github/workflows/lily58.yml
+++ b/.github/workflows/lily58.yml
@@ -17,18 +17,22 @@ jobs:
       config_path: lily58
       archive_name: lily58-firmware
         
-  lily58-store:
-    if: always()
+  lily58-release:
     needs: lily58-build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-    - uses: actions/checkout@v4
     - uses: actions/download-artifact@v4
       with:
-        path: lily58
+        path: firmware
         merge-multiple: true
-    - uses: sylvanld/action-storage@v1
+    - name: Publish firmware as a rolling release
+      uses: softprops/action-gh-release@v2
       with:
-        src: lily58
-        dst: ./
-        storage-branch: main
+        tag_name: lily58-firmware
+        name: Lily58 Firmware (latest)
+        body: |
+          Latest Lily58 ZMK firmware, built automatically from `main`.
+          Includes Wireless (BLE) and Wired (UART) variants for nice!nano and Mikoto.
+        files: firmware/*.uf2

--- a/.github/workflows/sofle.yml
+++ b/.github/workflows/sofle.yml
@@ -17,19 +17,23 @@ jobs:
       config_path: sofle
       archive_name: sofle-firmware
 
-  sofle-store:
-    if: always()
+  sofle-release:
     needs: sofle-build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-    - uses: actions/checkout@v4
     - uses: actions/download-artifact@v4
       with:
-        path: sofle
+        path: firmware
         merge-multiple: true
-    - uses: sylvanld/action-storage@v1
+    - name: Publish firmware as a rolling release
+      uses: softprops/action-gh-release@v2
       with:
-        src: sofle
-        dst: ./
-        storage-branch: main
+        tag_name: sofle-firmware
+        name: Sofle Firmware (latest)
+        body: |
+          Latest Sofle ZMK firmware, built automatically from `main`.
+          Includes Wireless (BLE) and Wired (UART) variants for nice!nano and Mikoto.
+        files: firmware/*.uf2
     

--- a/.github/workflows/yampad.yml
+++ b/.github/workflows/yampad.yml
@@ -17,19 +17,23 @@ jobs:
       config_path: yampad
       archive_name: yampad-firmware
 
-  yampad-store:
-    if: always()
+  yampad-release:
     needs: yampad-build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-    - uses: actions/checkout@v4
     - uses: actions/download-artifact@v4
       with:
-        path: yampad
+        path: firmware
         merge-multiple: true
-    - uses: sylvanld/action-storage@v1
+    - name: Publish firmware as a rolling release
+      uses: softprops/action-gh-release@v2
       with:
-        src: yampad
-        dst: ./
-        storage-branch: main
+        tag_name: yampad-firmware
+        name: Yampad Firmware (latest)
+        body: |
+          Latest Yampad ZMK firmware, built automatically from `main`.
+          Wireless (BLE) variants for nice!nano and Mikoto.
+        files: firmware/*.uf2
     

--- a/corne/corne.yaml
+++ b/corne/corne.yaml
@@ -1,48 +1,71 @@
 ---
+# artifact-name sets the exact .uf2 base name (used verbatim by ZMK's
+# build-user-config). Kept clean/URL-safe (no spaces or @) so the files
+# publish as tidy GitHub Release assets and the docs links stay stable,
+# independent of the Zephyr 4.1 board id (nice_nano//zmk, mikoto@7.2//zmk).
 include:
+  # --- Wireless (BLE) ---
   - board: nice_nano//zmk
     shield: corne_left
     snippet: studio-rpc-usb-uart
+    artifact-name: corne_left-nice_nano_v2-zmk
   - board: nice_nano//zmk
     shield: corne_right
+    artifact-name: corne_right-nice_nano_v2-zmk
   - board: nice_nano//zmk
     shield: corne_left nice_view_adapter nice_view
     snippet: studio-rpc-usb-uart
+    artifact-name: corne_left_display-nice_nano_v2-zmk
   - board: nice_nano//zmk
     shield: corne_right nice_view_adapter nice_view
+    artifact-name: corne_right_display-nice_nano_v2-zmk
   - board: mikoto@7.2//zmk
     shield: corne_left
     snippet: studio-rpc-usb-uart
+    artifact-name: corne_left-mikoto_7.2-zmk
   - board: mikoto@7.2//zmk
-    shield: corne_right 
+    shield: corne_right
+    artifact-name: corne_right-mikoto_7.2-zmk
   - board: mikoto@7.2//zmk
     shield: corne_left nice_view_adapter nice_view
     snippet: studio-rpc-usb-uart
+    artifact-name: corne_left_display-mikoto_7.2-zmk
   - board: mikoto@7.2//zmk
     shield: corne_right nice_view_adapter nice_view
-  # Wired UART split variants (inter-half comms over TRRS data wires, not BLE).
-  # Separate firmware from the wireless builds above — flash one set or the other.
+    artifact-name: corne_right_display-mikoto_7.2-zmk
+  # --- Wired UART (inter-half comms over TRRS data wires, not BLE) ---
   - board: nice_nano//zmk
     shield: corne_left wired
     snippet: studio-rpc-usb-uart
+    artifact-name: corne_left_wired-nice_nano_v2-zmk
   - board: nice_nano//zmk
     shield: corne_right wired
+    artifact-name: corne_right_wired-nice_nano_v2-zmk
   - board: nice_nano//zmk
     shield: corne_left nice_view_adapter nice_view wired
     snippet: studio-rpc-usb-uart
+    artifact-name: corne_left_display_wired-nice_nano_v2-zmk
   - board: nice_nano//zmk
     shield: corne_right nice_view_adapter nice_view wired
+    artifact-name: corne_right_display_wired-nice_nano_v2-zmk
   - board: mikoto@7.2//zmk
     shield: corne_left wired
     snippet: studio-rpc-usb-uart
+    artifact-name: corne_left_wired-mikoto_7.2-zmk
   - board: mikoto@7.2//zmk
     shield: corne_right wired
+    artifact-name: corne_right_wired-mikoto_7.2-zmk
   - board: mikoto@7.2//zmk
     shield: corne_left nice_view_adapter nice_view wired
     snippet: studio-rpc-usb-uart
+    artifact-name: corne_left_display_wired-mikoto_7.2-zmk
   - board: mikoto@7.2//zmk
     shield: corne_right nice_view_adapter nice_view wired
+    artifact-name: corne_right_display_wired-mikoto_7.2-zmk
+  # --- Settings reset ---
   - board: nice_nano//zmk
     shield: settings_reset
+    artifact-name: settings_reset-nice_nano_v2-zmk
   - board: mikoto@7.2//zmk
     shield: settings_reset
+    artifact-name: settings_reset-mikoto_7.2-zmk

--- a/corne/corne.yaml
+++ b/corne/corne.yaml
@@ -1,48 +1,48 @@
 ---
 include:
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: corne_left
     snippet: studio-rpc-usb-uart
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: corne_right
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: corne_left nice_view_adapter nice_view
     snippet: studio-rpc-usb-uart
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: corne_right nice_view_adapter nice_view
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: corne_left
     snippet: studio-rpc-usb-uart
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: corne_right 
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: corne_left nice_view_adapter nice_view
     snippet: studio-rpc-usb-uart
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: corne_right nice_view_adapter nice_view
   # Wired UART split variants (inter-half comms over TRRS data wires, not BLE).
   # Separate firmware from the wireless builds above — flash one set or the other.
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: corne_left wired
     snippet: studio-rpc-usb-uart
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: corne_right wired
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: corne_left nice_view_adapter nice_view wired
     snippet: studio-rpc-usb-uart
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: corne_right nice_view_adapter nice_view wired
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: corne_left wired
     snippet: studio-rpc-usb-uart
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: corne_right wired
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: corne_left nice_view_adapter nice_view wired
     snippet: studio-rpc-usb-uart
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: corne_right nice_view_adapter nice_view wired
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: settings_reset
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: settings_reset

--- a/corne/west.yml
+++ b/corne/west.yml
@@ -5,7 +5,9 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: main
+      # Pinned to a known-good zmkfirmware/zmk commit on main (Zephyr 4.1).
+      # Bumped via Renovate (see /renovate.json) so upgrades arrive as reviewable PRs.
+      revision: 64daf698e073e37b6748ac54f4eb48d8666af0b9
       import: app/west.yml
   self:
     path: config

--- a/lily58/lily58.yaml
+++ b/lily58/lily58.yaml
@@ -1,48 +1,48 @@
 ---
 include:
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: lily58_left
     snippet: studio-rpc-usb-uart
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: lily58_right
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: lily58_left nice_view_adapter nice_view
     snippet: studio-rpc-usb-uart
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: lily58_right nice_view_adapter nice_view
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: lily58_left
     snippet: studio-rpc-usb-uart
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: lily58_right
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: lily58_left nice_view_adapter nice_view
     snippet: studio-rpc-usb-uart
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: lily58_right nice_view_adapter nice_view
   # Wired UART split variants (inter-half comms over TRRS data wires, not BLE).
   # Separate firmware from the wireless builds above — flash one set or the other.
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: lily58_left wired
     snippet: studio-rpc-usb-uart
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: lily58_right wired
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: lily58_left nice_view_adapter nice_view wired
     snippet: studio-rpc-usb-uart
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: lily58_right nice_view_adapter nice_view wired
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: lily58_left wired
     snippet: studio-rpc-usb-uart
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: lily58_right wired
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: lily58_left nice_view_adapter nice_view wired
     snippet: studio-rpc-usb-uart
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: lily58_right nice_view_adapter nice_view wired
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: settings_reset
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: settings_reset

--- a/lily58/lily58.yaml
+++ b/lily58/lily58.yaml
@@ -1,48 +1,71 @@
 ---
+# artifact-name sets the exact .uf2 base name (used verbatim by ZMK's
+# build-user-config). Kept clean/URL-safe (no spaces or @) so the files
+# publish as tidy GitHub Release assets and the docs links stay stable,
+# independent of the Zephyr 4.1 board id (nice_nano//zmk, mikoto@7.2//zmk).
 include:
+  # --- Wireless (BLE) ---
   - board: nice_nano//zmk
     shield: lily58_left
     snippet: studio-rpc-usb-uart
+    artifact-name: lily58_left-nice_nano_v2-zmk
   - board: nice_nano//zmk
     shield: lily58_right
+    artifact-name: lily58_right-nice_nano_v2-zmk
   - board: nice_nano//zmk
     shield: lily58_left nice_view_adapter nice_view
     snippet: studio-rpc-usb-uart
+    artifact-name: lily58_left_display-nice_nano_v2-zmk
   - board: nice_nano//zmk
     shield: lily58_right nice_view_adapter nice_view
+    artifact-name: lily58_right_display-nice_nano_v2-zmk
   - board: mikoto@7.2//zmk
     shield: lily58_left
     snippet: studio-rpc-usb-uart
+    artifact-name: lily58_left-mikoto_7.2-zmk
   - board: mikoto@7.2//zmk
     shield: lily58_right
+    artifact-name: lily58_right-mikoto_7.2-zmk
   - board: mikoto@7.2//zmk
     shield: lily58_left nice_view_adapter nice_view
     snippet: studio-rpc-usb-uart
+    artifact-name: lily58_left_display-mikoto_7.2-zmk
   - board: mikoto@7.2//zmk
     shield: lily58_right nice_view_adapter nice_view
-  # Wired UART split variants (inter-half comms over TRRS data wires, not BLE).
-  # Separate firmware from the wireless builds above — flash one set or the other.
+    artifact-name: lily58_right_display-mikoto_7.2-zmk
+  # --- Wired UART (inter-half comms over TRRS data wires, not BLE) ---
   - board: nice_nano//zmk
     shield: lily58_left wired
     snippet: studio-rpc-usb-uart
+    artifact-name: lily58_left_wired-nice_nano_v2-zmk
   - board: nice_nano//zmk
     shield: lily58_right wired
+    artifact-name: lily58_right_wired-nice_nano_v2-zmk
   - board: nice_nano//zmk
     shield: lily58_left nice_view_adapter nice_view wired
     snippet: studio-rpc-usb-uart
+    artifact-name: lily58_left_display_wired-nice_nano_v2-zmk
   - board: nice_nano//zmk
     shield: lily58_right nice_view_adapter nice_view wired
+    artifact-name: lily58_right_display_wired-nice_nano_v2-zmk
   - board: mikoto@7.2//zmk
     shield: lily58_left wired
     snippet: studio-rpc-usb-uart
+    artifact-name: lily58_left_wired-mikoto_7.2-zmk
   - board: mikoto@7.2//zmk
     shield: lily58_right wired
+    artifact-name: lily58_right_wired-mikoto_7.2-zmk
   - board: mikoto@7.2//zmk
     shield: lily58_left nice_view_adapter nice_view wired
     snippet: studio-rpc-usb-uart
+    artifact-name: lily58_left_display_wired-mikoto_7.2-zmk
   - board: mikoto@7.2//zmk
     shield: lily58_right nice_view_adapter nice_view wired
+    artifact-name: lily58_right_display_wired-mikoto_7.2-zmk
+  # --- Settings reset ---
   - board: nice_nano//zmk
     shield: settings_reset
+    artifact-name: settings_reset-nice_nano_v2-zmk
   - board: mikoto@7.2//zmk
     shield: settings_reset
+    artifact-name: settings_reset-mikoto_7.2-zmk

--- a/lily58/west.yml
+++ b/lily58/west.yml
@@ -5,7 +5,9 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: main
+      # Pinned to a known-good zmkfirmware/zmk commit on main (Zephyr 4.1).
+      # Bumped via Renovate (see /renovate.json) so upgrades arrive as reviewable PRs.
+      revision: 64daf698e073e37b6748ac54f4eb48d8666af0b9
       import: app/west.yml
   self:
     path: config

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": [
+    "dependencies",
+    "zmk"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track the pinned zmkfirmware/zmk revision in each keyboard's west.yml",
+      "managerFilePatterns": [
+        "/(^|/)west\\.yml$/"
+      ],
+      "matchStrings": [
+        "-\\s*name:\\s*zmk[\\s\\S]*?revision:\\s*(?<currentDigest>[0-9a-f]{40})"
+      ],
+      "currentValueTemplate": "main",
+      "depNameTemplate": "zmkfirmware/zmk",
+      "packageNameTemplate": "https://github.com/zmkfirmware/zmk",
+      "datasourceTemplate": "git-refs"
+    }
+  ],
+  "git-refs": {
+    "schedule": [
+      "before 6am on monday"
+    ]
+  }
+}

--- a/sofle/sofle.yaml
+++ b/sofle/sofle.yaml
@@ -1,48 +1,71 @@
 ---
+# artifact-name sets the exact .uf2 base name (used verbatim by ZMK's
+# build-user-config). Kept clean/URL-safe (no spaces or @) so the files
+# publish as tidy GitHub Release assets and the docs links stay stable,
+# independent of the Zephyr 4.1 board id (nice_nano//zmk, mikoto@7.2//zmk).
 include:
+  # --- Wireless (BLE) ---
   - board: nice_nano//zmk
     shield: sofle_left
     snippet: studio-rpc-usb-uart
+    artifact-name: sofle_left-nice_nano_v2-zmk
   - board: nice_nano//zmk
     shield: sofle_right
+    artifact-name: sofle_right-nice_nano_v2-zmk
   - board: nice_nano//zmk
     shield: sofle_left nice_view_adapter nice_view
     snippet: studio-rpc-usb-uart
+    artifact-name: sofle_left_display-nice_nano_v2-zmk
   - board: nice_nano//zmk
     shield: sofle_right nice_view_adapter nice_view
+    artifact-name: sofle_right_display-nice_nano_v2-zmk
   - board: mikoto@7.2//zmk
     shield: sofle_left
     snippet: studio-rpc-usb-uart
+    artifact-name: sofle_left-mikoto_7.2-zmk
   - board: mikoto@7.2//zmk
     shield: sofle_right
+    artifact-name: sofle_right-mikoto_7.2-zmk
   - board: mikoto@7.2//zmk
     shield: sofle_left nice_view_adapter nice_view
     snippet: studio-rpc-usb-uart
+    artifact-name: sofle_left_display-mikoto_7.2-zmk
   - board: mikoto@7.2//zmk
     shield: sofle_right nice_view_adapter nice_view
-  # Wired UART split variants (inter-half comms over TRRS data wires, not BLE).
-  # Separate firmware from the wireless builds above — flash one set or the other.
+    artifact-name: sofle_right_display-mikoto_7.2-zmk
+  # --- Wired UART (inter-half comms over TRRS data wires, not BLE) ---
   - board: nice_nano//zmk
     shield: sofle_left wired
     snippet: studio-rpc-usb-uart
+    artifact-name: sofle_left_wired-nice_nano_v2-zmk
   - board: nice_nano//zmk
     shield: sofle_right wired
+    artifact-name: sofle_right_wired-nice_nano_v2-zmk
   - board: nice_nano//zmk
     shield: sofle_left nice_view_adapter nice_view wired
     snippet: studio-rpc-usb-uart
+    artifact-name: sofle_left_display_wired-nice_nano_v2-zmk
   - board: nice_nano//zmk
     shield: sofle_right nice_view_adapter nice_view wired
+    artifact-name: sofle_right_display_wired-nice_nano_v2-zmk
   - board: mikoto@7.2//zmk
     shield: sofle_left wired
     snippet: studio-rpc-usb-uart
+    artifact-name: sofle_left_wired-mikoto_7.2-zmk
   - board: mikoto@7.2//zmk
     shield: sofle_right wired
+    artifact-name: sofle_right_wired-mikoto_7.2-zmk
   - board: mikoto@7.2//zmk
     shield: sofle_left nice_view_adapter nice_view wired
     snippet: studio-rpc-usb-uart
+    artifact-name: sofle_left_display_wired-mikoto_7.2-zmk
   - board: mikoto@7.2//zmk
     shield: sofle_right nice_view_adapter nice_view wired
+    artifact-name: sofle_right_display_wired-mikoto_7.2-zmk
+  # --- Settings reset ---
   - board: nice_nano//zmk
     shield: settings_reset
+    artifact-name: settings_reset-nice_nano_v2-zmk
   - board: mikoto@7.2//zmk
     shield: settings_reset
+    artifact-name: settings_reset-mikoto_7.2-zmk

--- a/sofle/sofle.yaml
+++ b/sofle/sofle.yaml
@@ -1,48 +1,48 @@
 ---
 include:
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: sofle_left
     snippet: studio-rpc-usb-uart
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: sofle_right
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: sofle_left nice_view_adapter nice_view
     snippet: studio-rpc-usb-uart
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: sofle_right nice_view_adapter nice_view
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: sofle_left
     snippet: studio-rpc-usb-uart
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: sofle_right
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: sofle_left nice_view_adapter nice_view
     snippet: studio-rpc-usb-uart
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: sofle_right nice_view_adapter nice_view
   # Wired UART split variants (inter-half comms over TRRS data wires, not BLE).
   # Separate firmware from the wireless builds above — flash one set or the other.
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: sofle_left wired
     snippet: studio-rpc-usb-uart
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: sofle_right wired
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: sofle_left nice_view_adapter nice_view wired
     snippet: studio-rpc-usb-uart
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: sofle_right nice_view_adapter nice_view wired
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: sofle_left wired
     snippet: studio-rpc-usb-uart
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: sofle_right wired
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: sofle_left nice_view_adapter nice_view wired
     snippet: studio-rpc-usb-uart
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: sofle_right nice_view_adapter nice_view wired
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: settings_reset
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: settings_reset

--- a/sofle/west.yml
+++ b/sofle/west.yml
@@ -5,7 +5,9 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: main
+      # Pinned to a known-good zmkfirmware/zmk commit on main (Zephyr 4.1).
+      # Bumped via Renovate (see /renovate.json) so upgrades arrive as reviewable PRs.
+      revision: 64daf698e073e37b6748ac54f4eb48d8666af0b9
       import: app/west.yml
   self:
     path: config

--- a/yampad/west.yml
+++ b/yampad/west.yml
@@ -5,7 +5,9 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: main
+      # Pinned to a known-good zmkfirmware/zmk commit on main (Zephyr 4.1).
+      # Bumped via Renovate (see /renovate.json) so upgrades arrive as reviewable PRs.
+      revision: 64daf698e073e37b6748ac54f4eb48d8666af0b9
       import: app/west.yml
   self:
     path: config

--- a/yampad/yampad.yaml
+++ b/yampad/yampad.yaml
@@ -1,18 +1,18 @@
 ---
 include:
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: yampad
     snippet: studio-rpc-usb-uart
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: yampad nice_view_adapter nice_view
     snippet: studio-rpc-usb-uart
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: yampad
     snippet: studio-rpc-usb-uart
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: yampad nice_view_adapter nice_view
     snippet: studio-rpc-usb-uart
-  - board: nice_nano_v2
+  - board: nice_nano//zmk
     shield: settings_reset
-  - board: mikoto@7.2
+  - board: mikoto@7.2//zmk
     shield: settings_reset

--- a/yampad/yampad.yaml
+++ b/yampad/yampad.yaml
@@ -1,18 +1,29 @@
 ---
+# artifact-name sets the exact .uf2 base name (used verbatim by ZMK's
+# build-user-config). Kept clean/URL-safe (no spaces or @) so the files
+# publish as tidy GitHub Release assets and the docs links stay stable,
+# independent of the Zephyr 4.1 board id (nice_nano//zmk, mikoto@7.2//zmk).
+# Yampad is a unibody numpad: no split halves and no wired-UART variants.
 include:
   - board: nice_nano//zmk
     shield: yampad
     snippet: studio-rpc-usb-uart
+    artifact-name: yampad-nice_nano_v2-zmk
   - board: nice_nano//zmk
     shield: yampad nice_view_adapter nice_view
     snippet: studio-rpc-usb-uart
+    artifact-name: yampad_display-nice_nano_v2-zmk
   - board: mikoto@7.2//zmk
     shield: yampad
     snippet: studio-rpc-usb-uart
+    artifact-name: yampad-mikoto_7.2-zmk
   - board: mikoto@7.2//zmk
     shield: yampad nice_view_adapter nice_view
     snippet: studio-rpc-usb-uart
+    artifact-name: yampad_display-mikoto_7.2-zmk
   - board: nice_nano//zmk
     shield: settings_reset
+    artifact-name: settings_reset-nice_nano_v2-zmk
   - board: mikoto@7.2//zmk
     shield: settings_reset
+    artifact-name: settings_reset-mikoto_7.2-zmk


### PR DESCRIPTION
## Why

After #5 merged, **every** firmware build failed (wireless, wired, and settings_reset alike). Root cause is upstream: ZMK `main` moved to **Zephyr 4.1 (Hardware Model v2)**, which requires the `/zmk` board variant — the old bare board targets no longer link (`undefined reference to retention_* / __device_dts_ord_*`). Our `west.yml` tracked `revision: main`, so we inherited the break.

Pinning to the last stable tag (`v0.3.0`) is **not** an option: the wired UART split feature only exists post-`v0.3.0` on `main`.

## What

- **Board IDs** (all four matrices): `nice_nano_v2` → `nice_nano//zmk`, `mikoto@7.2` → `mikoto@7.2//zmk`.
- **Pin `west.yml`** from `main` to a known-good commit (`64daf69`) so upstream can't silently break builds again.
- **Renovate** (`renovate.json`): a custom manager tracks the pinned `zmkfirmware/zmk` digest and opens upgrade PRs (Dependabot can't watch `west.yml`).
- **Publish via GitHub Releases**: branch protection now rejects the old `action-storage` push to `main`, so each workflow publishes `.uf2`s to a rolling release (`<keyboard>-firmware`) via `softprops/action-gh-release`.
- **`artifact-name`** on every matrix entry → clean, URL-safe asset names (`corne_left_wired-nice_nano_v2-zmk.uf2`) instead of the board-id-derived `…nice_nano__zmk-zmk.uf2`.

## Validation (workflow_dispatch on this branch)

All four keyboards built green and published releases:

| Release | Assets |
|---|---|
| corne-firmware | 18 |
| lily58-firmware | 18 |
| sofle-firmware | 18 |
| yampad-firmware | 6 |

All 60 download URLs verified resolving (HTTP 200), including wired variants. Companion docs update: keebd/keebd-docs#4.

## Notes / follow-ups

- The Corne workflow's `draw` (keymap-drawer) job fails on `no west.yml found in /config` — **pre-existing and unrelated** to firmware; not addressed here.
- Wired UART still needs the hardware prereqs confirmed (both TRRS data wires; `&pro_micro_serial` on mikoto) before advertising as supported.
- Switch Renovate's datasource to `github-releases` once ZMK cuts a release containing Zephyr 4.1 + wired UART.

🤖 Generated with [Claude Code](https://claude.com/claude-code)