### PR TITLE
Fix wired split firmware: force interrupt UART (async hangs nRF52)

### DIFF
--- a/corne/boards/shields/wired/Kconfig.defconfig
+++ b/corne/boards/shields/wired/Kconfig.defconfig
@@ -1,8 +1,0 @@
-if SHIELD_WIRED
-
-# Inter-half comms go over the wire, not BLE. Host connectivity (USB/BLE)
-# is unaffected. Only one split transport can be active per build.
-config ZMK_SPLIT_BLE
-    default n
-
-endif

--- a/corne/boards/shields/wired/wired.conf
+++ b/corne/boards/shields/wired/wired.conf
@@ -1,12 +1,14 @@
-# Wired UART split configuration (auto-loaded by Zephyr for the `wired` shield).
+# Wired UART split tuning (auto-loaded by Zephyr for the `wired` shield).
 #
-# Only one split transport can be active at a time. ZMK_SPLIT_BLE defaults to y
-# (it depends only on ZMK_BLE), so it must be turned off explicitly for wired
-# builds — otherwise BLE and wired transports are both compiled and the firmware
-# fails to boot. A shield .conf fragment overrides Kconfig defaults reliably; a
-# Kconfig.defconfig `default n` does not (ZMK's `default y` wins on parse order).
-CONFIG_ZMK_SPLIT_BLE=n
-
-# Force interrupt-driven UART. Async/DMA mode is auto-selected on nRF52 but is
-# known-buggy there (see zmk/app/src/split/wired/Kconfig), which hangs boot.
+# Force interrupt-driven UART. On nRF52, async/DMA mode is auto-selected but is
+# known-buggy there (see zmk/app/src/split/wired/Kconfig: "don't use async/DMA
+# on nRF52 due to RX bug"), which hangs the firmware at boot. A shield .conf
+# fragment reliably overrides the Kconfig choice default.
 CONFIG_ZMK_SPLIT_WIRED_UART_MODE_INTERRUPT=y
+
+# NOTE: the BLE split transport is intentionally left enabled. ZMK compiles both
+# the BLE and wired transports and selects one at runtime by priority
+# (ZMK_SPLIT_WIRED_PRIORITY=0 is favored over ZMK_SPLIT_BLE_PRIORITY=1), so the
+# wired link is used when present. Disabling ZMK_SPLIT_BLE breaks the peripheral
+# build: the display's output_status widget references BLE endpoint symbols that
+# only compile when the BLE split is present.

--- a/corne/boards/shields/wired/wired.conf
+++ b/corne/boards/shields/wired/wired.conf
@@ -1,0 +1,12 @@
+# Wired UART split configuration (auto-loaded by Zephyr for the `wired` shield).
+#
+# Only one split transport can be active at a time. ZMK_SPLIT_BLE defaults to y
+# (it depends only on ZMK_BLE), so it must be turned off explicitly for wired
+# builds — otherwise BLE and wired transports are both compiled and the firmware
+# fails to boot. A shield .conf fragment overrides Kconfig defaults reliably; a
+# Kconfig.defconfig `default n` does not (ZMK's `default y` wins on parse order).
+CONFIG_ZMK_SPLIT_BLE=n
+
+# Force interrupt-driven UART. Async/DMA mode is auto-selected on nRF52 but is
+# known-buggy there (see zmk/app/src/split/wired/Kconfig), which hangs boot.
+CONFIG_ZMK_SPLIT_WIRED_UART_MODE_INTERRUPT=y

--- a/lily58/boards/shields/wired/Kconfig.defconfig
+++ b/lily58/boards/shields/wired/Kconfig.defconfig
@@ -1,8 +1,0 @@
-if SHIELD_WIRED
-
-# Inter-half comms go over the wire, not BLE. Host connectivity (USB/BLE)
-# is unaffected. Only one split transport can be active per build.
-config ZMK_SPLIT_BLE
-    default n
-
-endif

--- a/lily58/boards/shields/wired/wired.conf
+++ b/lily58/boards/shields/wired/wired.conf
@@ -1,12 +1,14 @@
-# Wired UART split configuration (auto-loaded by Zephyr for the `wired` shield).
+# Wired UART split tuning (auto-loaded by Zephyr for the `wired` shield).
 #
-# Only one split transport can be active at a time. ZMK_SPLIT_BLE defaults to y
-# (it depends only on ZMK_BLE), so it must be turned off explicitly for wired
-# builds — otherwise BLE and wired transports are both compiled and the firmware
-# fails to boot. A shield .conf fragment overrides Kconfig defaults reliably; a
-# Kconfig.defconfig `default n` does not (ZMK's `default y` wins on parse order).
-CONFIG_ZMK_SPLIT_BLE=n
-
-# Force interrupt-driven UART. Async/DMA mode is auto-selected on nRF52 but is
-# known-buggy there (see zmk/app/src/split/wired/Kconfig), which hangs boot.
+# Force interrupt-driven UART. On nRF52, async/DMA mode is auto-selected but is
+# known-buggy there (see zmk/app/src/split/wired/Kconfig: "don't use async/DMA
+# on nRF52 due to RX bug"), which hangs the firmware at boot. A shield .conf
+# fragment reliably overrides the Kconfig choice default.
 CONFIG_ZMK_SPLIT_WIRED_UART_MODE_INTERRUPT=y
+
+# NOTE: the BLE split transport is intentionally left enabled. ZMK compiles both
+# the BLE and wired transports and selects one at runtime by priority
+# (ZMK_SPLIT_WIRED_PRIORITY=0 is favored over ZMK_SPLIT_BLE_PRIORITY=1), so the
+# wired link is used when present. Disabling ZMK_SPLIT_BLE breaks the peripheral
+# build: the display's output_status widget references BLE endpoint symbols that
+# only compile when the BLE split is present.

--- a/lily58/boards/shields/wired/wired.conf
+++ b/lily58/boards/shields/wired/wired.conf
@@ -1,0 +1,12 @@
+# Wired UART split configuration (auto-loaded by Zephyr for the `wired` shield).
+#
+# Only one split transport can be active at a time. ZMK_SPLIT_BLE defaults to y
+# (it depends only on ZMK_BLE), so it must be turned off explicitly for wired
+# builds — otherwise BLE and wired transports are both compiled and the firmware
+# fails to boot. A shield .conf fragment overrides Kconfig defaults reliably; a
+# Kconfig.defconfig `default n` does not (ZMK's `default y` wins on parse order).
+CONFIG_ZMK_SPLIT_BLE=n
+
+# Force interrupt-driven UART. Async/DMA mode is auto-selected on nRF52 but is
+# known-buggy there (see zmk/app/src/split/wired/Kconfig), which hangs boot.
+CONFIG_ZMK_SPLIT_WIRED_UART_MODE_INTERRUPT=y

--- a/sofle/boards/shields/wired/Kconfig.defconfig
+++ b/sofle/boards/shields/wired/Kconfig.defconfig
@@ -1,8 +1,0 @@
-if SHIELD_WIRED
-
-# Inter-half comms go over the wire, not BLE. Host connectivity (USB/BLE)
-# is unaffected. Only one split transport can be active per build.
-config ZMK_SPLIT_BLE
-    default n
-
-endif

--- a/sofle/boards/shields/wired/wired.conf
+++ b/sofle/boards/shields/wired/wired.conf
@@ -1,12 +1,14 @@
-# Wired UART split configuration (auto-loaded by Zephyr for the `wired` shield).
+# Wired UART split tuning (auto-loaded by Zephyr for the `wired` shield).
 #
-# Only one split transport can be active at a time. ZMK_SPLIT_BLE defaults to y
-# (it depends only on ZMK_BLE), so it must be turned off explicitly for wired
-# builds — otherwise BLE and wired transports are both compiled and the firmware
-# fails to boot. A shield .conf fragment overrides Kconfig defaults reliably; a
-# Kconfig.defconfig `default n` does not (ZMK's `default y` wins on parse order).
-CONFIG_ZMK_SPLIT_BLE=n
-
-# Force interrupt-driven UART. Async/DMA mode is auto-selected on nRF52 but is
-# known-buggy there (see zmk/app/src/split/wired/Kconfig), which hangs boot.
+# Force interrupt-driven UART. On nRF52, async/DMA mode is auto-selected but is
+# known-buggy there (see zmk/app/src/split/wired/Kconfig: "don't use async/DMA
+# on nRF52 due to RX bug"), which hangs the firmware at boot. A shield .conf
+# fragment reliably overrides the Kconfig choice default.
 CONFIG_ZMK_SPLIT_WIRED_UART_MODE_INTERRUPT=y
+
+# NOTE: the BLE split transport is intentionally left enabled. ZMK compiles both
+# the BLE and wired transports and selects one at runtime by priority
+# (ZMK_SPLIT_WIRED_PRIORITY=0 is favored over ZMK_SPLIT_BLE_PRIORITY=1), so the
+# wired link is used when present. Disabling ZMK_SPLIT_BLE breaks the peripheral
+# build: the display's output_status widget references BLE endpoint symbols that
+# only compile when the BLE split is present.

--- a/sofle/boards/shields/wired/wired.conf
+++ b/sofle/boards/shields/wired/wired.conf
@@ -1,0 +1,12 @@
+# Wired UART split configuration (auto-loaded by Zephyr for the `wired` shield).
+#
+# Only one split transport can be active at a time. ZMK_SPLIT_BLE defaults to y
+# (it depends only on ZMK_BLE), so it must be turned off explicitly for wired
+# builds — otherwise BLE and wired transports are both compiled and the firmware
+# fails to boot. A shield .conf fragment overrides Kconfig defaults reliably; a
+# Kconfig.defconfig `default n` does not (ZMK's `default y` wins on parse order).
+CONFIG_ZMK_SPLIT_BLE=n
+
+# Force interrupt-driven UART. Async/DMA mode is auto-selected on nRF52 but is
+# known-buggy there (see zmk/app/src/split/wired/Kconfig), which hangs boot.
+CONFIG_ZMK_SPLIT_WIRED_UART_MODE_INTERRUPT=y


### PR DESCRIPTION
## Problem

Wired firmware did not boot on Mikoto (Lily58) — no boot, no display. Wireless on the same board works.

## Root cause

The wired builds auto-selected **async/DMA UART mode on nRF52**, which ZMK's own Kconfig flags as known-buggy (`# don't use async/DMA on nRF52 due to RX bug`). That hangs the firmware at boot. Confirmed from the resolved `.config`: `CONFIG_ZMK_SPLIT_WIRED_UART_MODE_ASYNC=y`.

## Fix

Add a `wired.conf` shield fragment forcing interrupt mode:
```
CONFIG_ZMK_SPLIT_WIRED_UART_MODE_INTERRUPT=y
```
A `<shield>.conf` is auto-loaded by Zephyr and reliably overrides the Kconfig choice default (a `Kconfig.defconfig` `default` did not — wrong parse-order precedence, which also removed the earlier ineffective defconfig).

**BLE split is intentionally left enabled.** ZMK compiles both transports and selects one at runtime by priority (`WIRED=0` beats `BLE=1`), so the wired link is used. Disabling `ZMK_SPLIT_BLE` breaks the peripheral build — the display `output_status` widget references BLE endpoint symbols that only compile with the BLE split present.

## Validation

Lily58 `workflow_dispatch` build is fully green: all 8 wired variants compile (both halves, both boards, ±display), and the resolved config shows `CONFIG_ZMK_SPLIT_WIRED_UART_MODE_INTERRUPT=y`.

⚠️ Still needs on-hardware confirmation (boot + inter-half comms). Note the Mikoto UART pins are P0.04 (RX) / P0.08 (TX) — both must be routed across the TRRS for full-duplex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wired split keyboard stability across multiple boards by optimizing transport mode handling. Wired UART now uses interrupt-driven mode to prevent boot issues, while the system intelligently switches between wired and wireless transports at runtime based on availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->