### PR TITLE
Fix keymap diagram (draw) job and publish SVG to releases (all keyboards)

### DIFF
--- a/.github/workflows/corne.yml
+++ b/.github/workflows/corne.yml
@@ -18,18 +18,21 @@ jobs:
       archive_name: corne-firmware
 
   draw:
+    # Render the keymap diagram and publish it as an artifact (the SVG is added
+    # to the release below). west_config_path must point at the folder holding
+    # west.yml so module includes resolve; we keep west.yml per-keyboard.
     uses: caksoylar/keymap-drawer/.github/workflows/draw-zmk.yml@main
-    permissions:
-      contents: write  # allow workflow to commit to the repo
     with:
-      keymap_patterns: "corne/corne.keymap"        # path to the keymaps to parse
-      config_path: "keymap_drawer.config.yaml"  # config file, ignored if not exists
-      output_folder: "corne"            # path to save produced SVG and keymap YAML files
-      parse_args: ""  # map of extra args to pass to `keymap parse`, e.g. "corne:'-l Def Lwr Rse' cradio:''"
-      draw_args: ""   # map of extra args to pass to `keymap draw`, e.g. "corne:'-k corne_rotated' cradio:'-k paroxysm'"
+      keymap_patterns: "corne/corne.keymap"
+      config_path: "keymap_drawer.config.yaml"
+      west_config_path: "corne"
+      output_folder: "."
+      destination: "artifact"
+      artifact_name: "corne-keymap"
+      fail_on_error: false
 
   corne-release:
-    needs: corne-build
+    needs: [corne-build, draw]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -38,12 +41,15 @@ jobs:
       with:
         path: firmware
         merge-multiple: true
-    - name: Publish firmware as a rolling release
+    - name: Publish firmware + keymap diagram as a rolling release
       uses: softprops/action-gh-release@v2
       with:
         tag_name: corne-firmware
         name: Corne Firmware (latest)
         body: |
           Latest Corne ZMK firmware, built automatically from `main`.
-          Includes Wireless (BLE) and Wired (UART) variants for nice!nano and Mikoto.
-        files: firmware/*.uf2
+          Includes Wireless (BLE) and Wired (UART) variants for nice!nano and Mikoto,
+          plus the rendered keymap diagram (corne.svg).
+        files: |
+          firmware/*.uf2
+          firmware/*.svg

--- a/.github/workflows/lily58.yml
+++ b/.github/workflows/lily58.yml
@@ -16,9 +16,20 @@ jobs:
       build_matrix_path: lily58/lily58.yaml
       config_path: lily58
       archive_name: lily58-firmware
-        
+
+  draw:
+    uses: caksoylar/keymap-drawer/.github/workflows/draw-zmk.yml@main
+    with:
+      keymap_patterns: "lily58/lily58.keymap"
+      config_path: "keymap_drawer.config.yaml"
+      west_config_path: "lily58"
+      output_folder: "."
+      destination: "artifact"
+      artifact_name: "lily58-keymap"
+      fail_on_error: false
+
   lily58-release:
-    needs: lily58-build
+    needs: [lily58-build, draw]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -27,12 +38,15 @@ jobs:
       with:
         path: firmware
         merge-multiple: true
-    - name: Publish firmware as a rolling release
+    - name: Publish firmware + keymap diagram as a rolling release
       uses: softprops/action-gh-release@v2
       with:
         tag_name: lily58-firmware
         name: Lily58 Firmware (latest)
         body: |
           Latest Lily58 ZMK firmware, built automatically from `main`.
-          Includes Wireless (BLE) and Wired (UART) variants for nice!nano and Mikoto.
-        files: firmware/*.uf2
+          Includes Wireless (BLE) and Wired (UART) variants for nice!nano and Mikoto,
+          plus the rendered keymap diagram (lily58.svg).
+        files: |
+          firmware/*.uf2
+          firmware/*.svg

--- a/.github/workflows/sofle.yml
+++ b/.github/workflows/sofle.yml
@@ -17,8 +17,19 @@ jobs:
       config_path: sofle
       archive_name: sofle-firmware
 
+  draw:
+    uses: caksoylar/keymap-drawer/.github/workflows/draw-zmk.yml@main
+    with:
+      keymap_patterns: "sofle/sofle.keymap"
+      config_path: "keymap_drawer.config.yaml"
+      west_config_path: "sofle"
+      output_folder: "."
+      destination: "artifact"
+      artifact_name: "sofle-keymap"
+      fail_on_error: false
+
   sofle-release:
-    needs: sofle-build
+    needs: [sofle-build, draw]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -27,13 +38,16 @@ jobs:
       with:
         path: firmware
         merge-multiple: true
-    - name: Publish firmware as a rolling release
+    - name: Publish firmware + keymap diagram as a rolling release
       uses: softprops/action-gh-release@v2
       with:
         tag_name: sofle-firmware
         name: Sofle Firmware (latest)
         body: |
           Latest Sofle ZMK firmware, built automatically from `main`.
-          Includes Wireless (BLE) and Wired (UART) variants for nice!nano and Mikoto.
-        files: firmware/*.uf2
+          Includes Wireless (BLE) and Wired (UART) variants for nice!nano and Mikoto,
+          plus the rendered keymap diagram (sofle.svg).
+        files: |
+          firmware/*.uf2
+          firmware/*.svg
     

--- a/.github/workflows/yampad.yml
+++ b/.github/workflows/yampad.yml
@@ -17,8 +17,19 @@ jobs:
       config_path: yampad
       archive_name: yampad-firmware
 
+  draw:
+    uses: caksoylar/keymap-drawer/.github/workflows/draw-zmk.yml@main
+    with:
+      keymap_patterns: "yampad/yampad.keymap"
+      config_path: "keymap_drawer.config.yaml"
+      west_config_path: "yampad"
+      output_folder: "."
+      destination: "artifact"
+      artifact_name: "yampad-keymap"
+      fail_on_error: false
+
   yampad-release:
-    needs: yampad-build
+    needs: [yampad-build, draw]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -27,13 +38,16 @@ jobs:
       with:
         path: firmware
         merge-multiple: true
-    - name: Publish firmware as a rolling release
+    - name: Publish firmware + keymap diagram as a rolling release
       uses: softprops/action-gh-release@v2
       with:
         tag_name: yampad-firmware
         name: Yampad Firmware (latest)
         body: |
           Latest Yampad ZMK firmware, built automatically from `main`.
-          Wireless (BLE) variants for nice!nano and Mikoto.
-        files: firmware/*.uf2
+          Wireless (BLE) variants for nice!nano and Mikoto,
+          plus the rendered keymap diagram (yampad.svg).
+        files: |
+          firmware/*.uf2
+          firmware/*.svg
     


### PR DESCRIPTION
## What

Fixes the failing Corne `draw` job and adds a working keymap-diagram job to **all** keyboards, publishing the rendered SVG as a release asset for use in the docs.

## Fix

- `west_config_path` was defaulting to `config`; we keep `west.yml` per-keyboard, so it failed with *"no west.yml found in …/config"*. Point it at each keyboard's folder.
- `destination: artifact` (the default `commit` is blocked by branch protection), then include the SVG in each rolling release alongside the firmware.
- Add the job to lily58/sofle/yampad (only corne had one).

## Validation

All four keyboards built green and published `*.svg` to their `<keyboard>-firmware` release (e.g. `corne.svg` → HTTP 200, 26 KB).

> Note: third-party reusable workflows (`caksoylar/keymap-drawer`, `softprops/action-gh-release`) are referenced by mutable tags; pinning them to commit SHAs is a recommended follow-up (flagged by commit security review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)