### PR TITLE
Park wired UART split (single-wire boards unsupported by ZMK)

### DIFF
--- a/corne/boards/shields/wired/README.md
+++ b/corne/boards/shields/wired/README.md
@@ -1,0 +1,27 @@
+# `wired` add-on shield — PARKED (not currently built)
+
+This shield adds ZMK's **full-duplex wired UART** split transport on top of the
+`corne_left` / `corne_right` shields. It is **not built or published right now** —
+the matrix entries in `../../../corne.yaml` are commented out.
+
+## Why it's parked
+
+ZMK's wired split currently supports **full-duplex only**, which needs **two
+data wires** between the halves. The keebd Corne routes a **single shared data
+conductor** over the TRRS, and ZMK's **half-duplex (single-wire)** support is
+**not implemented yet** (see https://zmk.dev/docs/features/split-keyboards —
+"Full Duplex vs Half Duplex"). So wired split cannot function on the current
+hardware. These boards use the **Bluetooth (wireless)** transport.
+
+Additional hardware conflict on the current revision: the nice!view display
+**CS is on pro_micro D1**, which is also the default UART **TX** pin — so even
+full-duplex would clobber the display. A hardware revision that lands wired on
+the default UART pins (D0=RX, D1=TX) must also move the nice!view CS off D1.
+
+## Re-enabling later
+
+When ZMK ships half-duplex single-wire support (or a board revision adds a
+second TRRS data wire and relocates the display CS):
+1. Uncomment the wired entries in `corne.yaml`.
+2. Set the UART pins in `wired.overlay` to the TRRS data pin(s) for the revision.
+3. Re-add the download links in the keebd-docs firmware page.

--- a/corne/corne.yaml
+++ b/corne/corne.yaml
@@ -33,35 +33,42 @@ include:
   - board: mikoto@7.2//zmk
     shield: corne_right nice_view_adapter nice_view
     artifact-name: corne_right_display-mikoto_7.2-zmk
-  # --- Wired UART (inter-half comms over TRRS data wires, not BLE) ---
-  - board: nice_nano//zmk
-    shield: corne_left wired
-    snippet: studio-rpc-usb-uart
-    artifact-name: corne_left_wired-nice_nano_v2-zmk
-  - board: nice_nano//zmk
-    shield: corne_right wired
-    artifact-name: corne_right_wired-nice_nano_v2-zmk
-  - board: nice_nano//zmk
-    shield: corne_left nice_view_adapter nice_view wired
-    snippet: studio-rpc-usb-uart
-    artifact-name: corne_left_display_wired-nice_nano_v2-zmk
-  - board: nice_nano//zmk
-    shield: corne_right nice_view_adapter nice_view wired
-    artifact-name: corne_right_display_wired-nice_nano_v2-zmk
-  - board: mikoto@7.2//zmk
-    shield: corne_left wired
-    snippet: studio-rpc-usb-uart
-    artifact-name: corne_left_wired-mikoto_7.2-zmk
-  - board: mikoto@7.2//zmk
-    shield: corne_right wired
-    artifact-name: corne_right_wired-mikoto_7.2-zmk
-  - board: mikoto@7.2//zmk
-    shield: corne_left nice_view_adapter nice_view wired
-    snippet: studio-rpc-usb-uart
-    artifact-name: corne_left_display_wired-mikoto_7.2-zmk
-  - board: mikoto@7.2//zmk
-    shield: corne_right nice_view_adapter nice_view wired
-    artifact-name: corne_right_display_wired-mikoto_7.2-zmk
+  # --- Wired UART split: PARKED / NOT BUILT ---------------------------------
+  # ZMK's wired split currently supports full-duplex (TWO data wires) only.
+  # The keebd Corne/Lily58/Sofle route a SINGLE shared data wire over TRRS, and
+  # ZMK's half-duplex (single-wire) support is not implemented yet, so wired
+  # cannot work on these boards today. The `wired` add-on shield is kept under
+  # boards/shields/wired/ (see its README) so these entries can be re-enabled
+  # once ZMK ships half-duplex. Until then they are commented out so CI does
+  # not build or publish non-functional firmware.
+  # - board: nice_nano//zmk
+  # shield: corne_left wired
+  # snippet: studio-rpc-usb-uart
+  # artifact-name: corne_left_wired-nice_nano_v2-zmk
+  # - board: nice_nano//zmk
+  # shield: corne_right wired
+  # artifact-name: corne_right_wired-nice_nano_v2-zmk
+  # - board: nice_nano//zmk
+  # shield: corne_left nice_view_adapter nice_view wired
+  # snippet: studio-rpc-usb-uart
+  # artifact-name: corne_left_display_wired-nice_nano_v2-zmk
+  # - board: nice_nano//zmk
+  # shield: corne_right nice_view_adapter nice_view wired
+  # artifact-name: corne_right_display_wired-nice_nano_v2-zmk
+  # - board: mikoto@7.2//zmk
+  # shield: corne_left wired
+  # snippet: studio-rpc-usb-uart
+  # artifact-name: corne_left_wired-mikoto_7.2-zmk
+  # - board: mikoto@7.2//zmk
+  # shield: corne_right wired
+  # artifact-name: corne_right_wired-mikoto_7.2-zmk
+  # - board: mikoto@7.2//zmk
+  # shield: corne_left nice_view_adapter nice_view wired
+  # snippet: studio-rpc-usb-uart
+  # artifact-name: corne_left_display_wired-mikoto_7.2-zmk
+  # - board: mikoto@7.2//zmk
+  # shield: corne_right nice_view_adapter nice_view wired
+  # artifact-name: corne_right_display_wired-mikoto_7.2-zmk
   # --- Settings reset ---
   - board: nice_nano//zmk
     shield: settings_reset

--- a/lily58/boards/shields/wired/README.md
+++ b/lily58/boards/shields/wired/README.md
@@ -1,0 +1,27 @@
+# `wired` add-on shield — PARKED (not currently built)
+
+This shield adds ZMK's **full-duplex wired UART** split transport on top of the
+`lily58_left` / `lily58_right` shields. It is **not built or published right now** —
+the matrix entries in `../../../lily58.yaml` are commented out.
+
+## Why it's parked
+
+ZMK's wired split currently supports **full-duplex only**, which needs **two
+data wires** between the halves. The keebd Lily58 routes a **single shared data
+conductor** over the TRRS, and ZMK's **half-duplex (single-wire)** support is
+**not implemented yet** (see https://zmk.dev/docs/features/split-keyboards —
+"Full Duplex vs Half Duplex"). So wired split cannot function on the current
+hardware. These boards use the **Bluetooth (wireless)** transport.
+
+Additional hardware conflict on the current revision: the nice!view display
+**CS is on pro_micro D1**, which is also the default UART **TX** pin — so even
+full-duplex would clobber the display. A hardware revision that lands wired on
+the default UART pins (D0=RX, D1=TX) must also move the nice!view CS off D1.
+
+## Re-enabling later
+
+When ZMK ships half-duplex single-wire support (or a board revision adds a
+second TRRS data wire and relocates the display CS):
+1. Uncomment the wired entries in `lily58.yaml`.
+2. Set the UART pins in `wired.overlay` to the TRRS data pin(s) for the revision.
+3. Re-add the download links in the keebd-docs firmware page.

--- a/lily58/lily58.yaml
+++ b/lily58/lily58.yaml
@@ -33,35 +33,42 @@ include:
   - board: mikoto@7.2//zmk
     shield: lily58_right nice_view_adapter nice_view
     artifact-name: lily58_right_display-mikoto_7.2-zmk
-  # --- Wired UART (inter-half comms over TRRS data wires, not BLE) ---
-  - board: nice_nano//zmk
-    shield: lily58_left wired
-    snippet: studio-rpc-usb-uart
-    artifact-name: lily58_left_wired-nice_nano_v2-zmk
-  - board: nice_nano//zmk
-    shield: lily58_right wired
-    artifact-name: lily58_right_wired-nice_nano_v2-zmk
-  - board: nice_nano//zmk
-    shield: lily58_left nice_view_adapter nice_view wired
-    snippet: studio-rpc-usb-uart
-    artifact-name: lily58_left_display_wired-nice_nano_v2-zmk
-  - board: nice_nano//zmk
-    shield: lily58_right nice_view_adapter nice_view wired
-    artifact-name: lily58_right_display_wired-nice_nano_v2-zmk
-  - board: mikoto@7.2//zmk
-    shield: lily58_left wired
-    snippet: studio-rpc-usb-uart
-    artifact-name: lily58_left_wired-mikoto_7.2-zmk
-  - board: mikoto@7.2//zmk
-    shield: lily58_right wired
-    artifact-name: lily58_right_wired-mikoto_7.2-zmk
-  - board: mikoto@7.2//zmk
-    shield: lily58_left nice_view_adapter nice_view wired
-    snippet: studio-rpc-usb-uart
-    artifact-name: lily58_left_display_wired-mikoto_7.2-zmk
-  - board: mikoto@7.2//zmk
-    shield: lily58_right nice_view_adapter nice_view wired
-    artifact-name: lily58_right_display_wired-mikoto_7.2-zmk
+  # --- Wired UART split: PARKED / NOT BUILT ---------------------------------
+  # ZMK's wired split currently supports full-duplex (TWO data wires) only.
+  # The keebd Corne/Lily58/Sofle route a SINGLE shared data wire over TRRS, and
+  # ZMK's half-duplex (single-wire) support is not implemented yet, so wired
+  # cannot work on these boards today. The `wired` add-on shield is kept under
+  # boards/shields/wired/ (see its README) so these entries can be re-enabled
+  # once ZMK ships half-duplex. Until then they are commented out so CI does
+  # not build or publish non-functional firmware.
+  # - board: nice_nano//zmk
+  # shield: lily58_left wired
+  # snippet: studio-rpc-usb-uart
+  # artifact-name: lily58_left_wired-nice_nano_v2-zmk
+  # - board: nice_nano//zmk
+  # shield: lily58_right wired
+  # artifact-name: lily58_right_wired-nice_nano_v2-zmk
+  # - board: nice_nano//zmk
+  # shield: lily58_left nice_view_adapter nice_view wired
+  # snippet: studio-rpc-usb-uart
+  # artifact-name: lily58_left_display_wired-nice_nano_v2-zmk
+  # - board: nice_nano//zmk
+  # shield: lily58_right nice_view_adapter nice_view wired
+  # artifact-name: lily58_right_display_wired-nice_nano_v2-zmk
+  # - board: mikoto@7.2//zmk
+  # shield: lily58_left wired
+  # snippet: studio-rpc-usb-uart
+  # artifact-name: lily58_left_wired-mikoto_7.2-zmk
+  # - board: mikoto@7.2//zmk
+  # shield: lily58_right wired
+  # artifact-name: lily58_right_wired-mikoto_7.2-zmk
+  # - board: mikoto@7.2//zmk
+  # shield: lily58_left nice_view_adapter nice_view wired
+  # snippet: studio-rpc-usb-uart
+  # artifact-name: lily58_left_display_wired-mikoto_7.2-zmk
+  # - board: mikoto@7.2//zmk
+  # shield: lily58_right nice_view_adapter nice_view wired
+  # artifact-name: lily58_right_display_wired-mikoto_7.2-zmk
   # --- Settings reset ---
   - board: nice_nano//zmk
     shield: settings_reset

--- a/sofle/boards/shields/wired/README.md
+++ b/sofle/boards/shields/wired/README.md
@@ -1,0 +1,27 @@
+# `wired` add-on shield — PARKED (not currently built)
+
+This shield adds ZMK's **full-duplex wired UART** split transport on top of the
+`sofle_left` / `sofle_right` shields. It is **not built or published right now** —
+the matrix entries in `../../../sofle.yaml` are commented out.
+
+## Why it's parked
+
+ZMK's wired split currently supports **full-duplex only**, which needs **two
+data wires** between the halves. The keebd Sofle routes a **single shared data
+conductor** over the TRRS, and ZMK's **half-duplex (single-wire)** support is
+**not implemented yet** (see https://zmk.dev/docs/features/split-keyboards —
+"Full Duplex vs Half Duplex"). So wired split cannot function on the current
+hardware. These boards use the **Bluetooth (wireless)** transport.
+
+Additional hardware conflict on the current revision: the nice!view display
+**CS is on pro_micro D1**, which is also the default UART **TX** pin — so even
+full-duplex would clobber the display. A hardware revision that lands wired on
+the default UART pins (D0=RX, D1=TX) must also move the nice!view CS off D1.
+
+## Re-enabling later
+
+When ZMK ships half-duplex single-wire support (or a board revision adds a
+second TRRS data wire and relocates the display CS):
+1. Uncomment the wired entries in `sofle.yaml`.
+2. Set the UART pins in `wired.overlay` to the TRRS data pin(s) for the revision.
+3. Re-add the download links in the keebd-docs firmware page.

--- a/sofle/sofle.yaml
+++ b/sofle/sofle.yaml
@@ -33,35 +33,42 @@ include:
   - board: mikoto@7.2//zmk
     shield: sofle_right nice_view_adapter nice_view
     artifact-name: sofle_right_display-mikoto_7.2-zmk
-  # --- Wired UART (inter-half comms over TRRS data wires, not BLE) ---
-  - board: nice_nano//zmk
-    shield: sofle_left wired
-    snippet: studio-rpc-usb-uart
-    artifact-name: sofle_left_wired-nice_nano_v2-zmk
-  - board: nice_nano//zmk
-    shield: sofle_right wired
-    artifact-name: sofle_right_wired-nice_nano_v2-zmk
-  - board: nice_nano//zmk
-    shield: sofle_left nice_view_adapter nice_view wired
-    snippet: studio-rpc-usb-uart
-    artifact-name: sofle_left_display_wired-nice_nano_v2-zmk
-  - board: nice_nano//zmk
-    shield: sofle_right nice_view_adapter nice_view wired
-    artifact-name: sofle_right_display_wired-nice_nano_v2-zmk
-  - board: mikoto@7.2//zmk
-    shield: sofle_left wired
-    snippet: studio-rpc-usb-uart
-    artifact-name: sofle_left_wired-mikoto_7.2-zmk
-  - board: mikoto@7.2//zmk
-    shield: sofle_right wired
-    artifact-name: sofle_right_wired-mikoto_7.2-zmk
-  - board: mikoto@7.2//zmk
-    shield: sofle_left nice_view_adapter nice_view wired
-    snippet: studio-rpc-usb-uart
-    artifact-name: sofle_left_display_wired-mikoto_7.2-zmk
-  - board: mikoto@7.2//zmk
-    shield: sofle_right nice_view_adapter nice_view wired
-    artifact-name: sofle_right_display_wired-mikoto_7.2-zmk
+  # --- Wired UART split: PARKED / NOT BUILT ---------------------------------
+  # ZMK's wired split currently supports full-duplex (TWO data wires) only.
+  # The keebd Corne/Lily58/Sofle route a SINGLE shared data wire over TRRS, and
+  # ZMK's half-duplex (single-wire) support is not implemented yet, so wired
+  # cannot work on these boards today. The `wired` add-on shield is kept under
+  # boards/shields/wired/ (see its README) so these entries can be re-enabled
+  # once ZMK ships half-duplex. Until then they are commented out so CI does
+  # not build or publish non-functional firmware.
+  # - board: nice_nano//zmk
+  # shield: sofle_left wired
+  # snippet: studio-rpc-usb-uart
+  # artifact-name: sofle_left_wired-nice_nano_v2-zmk
+  # - board: nice_nano//zmk
+  # shield: sofle_right wired
+  # artifact-name: sofle_right_wired-nice_nano_v2-zmk
+  # - board: nice_nano//zmk
+  # shield: sofle_left nice_view_adapter nice_view wired
+  # snippet: studio-rpc-usb-uart
+  # artifact-name: sofle_left_display_wired-nice_nano_v2-zmk
+  # - board: nice_nano//zmk
+  # shield: sofle_right nice_view_adapter nice_view wired
+  # artifact-name: sofle_right_display_wired-nice_nano_v2-zmk
+  # - board: mikoto@7.2//zmk
+  # shield: sofle_left wired
+  # snippet: studio-rpc-usb-uart
+  # artifact-name: sofle_left_wired-mikoto_7.2-zmk
+  # - board: mikoto@7.2//zmk
+  # shield: sofle_right wired
+  # artifact-name: sofle_right_wired-mikoto_7.2-zmk
+  # - board: mikoto@7.2//zmk
+  # shield: sofle_left nice_view_adapter nice_view wired
+  # snippet: studio-rpc-usb-uart
+  # artifact-name: sofle_left_display_wired-mikoto_7.2-zmk
+  # - board: mikoto@7.2//zmk
+  # shield: sofle_right nice_view_adapter nice_view wired
+  # artifact-name: sofle_right_display_wired-mikoto_7.2-zmk
   # --- Settings reset ---
   - board: nice_nano//zmk
     shield: settings_reset


### PR DESCRIPTION
## Why

Hardware testing confirmed the wired firmware can't work on the current Corne/Lily58/Sofle:

- ZMK's wired split is **full-duplex only** (needs two data wires). These boards route a **single shared data wire** over the TRRS, and ZMK's **half-duplex (single-wire)** support is **not implemented yet** ([docs](https://zmk.dev/docs/features/split-keyboards) — "Full Duplex vs Half Duplex").
- Independently, the nice!view **CS is on pro_micro D1 = the default UART TX**, so even full-duplex would clobber the display (observed: keys work, display garbled/blank).

## What

- Comment out the wired entries in `corne/lily58/sofle` build matrices so CI stops building/publishing non-functional firmware.
- Keep the `wired` add-on shield under `boards/shields/wired/` (with a README) so it's ready to re-enable when ZMK ships half-duplex or a board revision adds a second data wire + relocates the display CS.
- Wired release assets have already been removed from the `*-firmware` releases; companion docs PR removes the wired download links.

Wireless (BLE) firmware is unaffected and remains the supported transport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for parked wired UART split transport feature across Corne, Lily58, and Sofle keyboards, explaining current status and hardware considerations.

* **Chores**
  * Disabled wired UART split firmware builds for multiple keyboard models to prevent publishing incomplete firmware variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->